### PR TITLE
Adds juce prefix and reads shaders from BinaryData

### DIFF
--- a/LearnJUCEOpenGL.jucer
+++ b/LearnJUCEOpenGL.jucer
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<JUCERPROJECT id="elZSSY" name="LearnJUCEOpenGL" projectType="guiapp" jucerVersion="5.4.2"
-              cppLanguageStandard="17" defines="GL_SILENCE_DEPRECATION=1">
+<JUCERPROJECT id="elZSSY" name="LearnJUCEOpenGL" projectType="guiapp" cppLanguageStandard="17"
+              defines="GL_SILENCE_DEPRECATION=1" jucerFormatVersion="1">
   <MAINGROUP id="nh8Tq6" name="LearnJUCEOpenGL">
     <GROUP id="{FE4AB671-DCD3-1A49-15A6-89842D0DC0EE}" name="Source">
       <GROUP id="{A2767812-80FE-BC9A-9F68-E28AA2BD7885}" name="Shaders">
-        <FILE id="gmV9U5" name="Frag.frag" compile="1" resource="0" file="/Users/cc/Dev/OpenGL Examples/LearnJUCEOpenGL/Source/Shaders/Frag.frag"/>
-        <FILE id="gcbPzr" name="Vert.vert" compile="1" resource="0" file="/Users/cc/Dev/OpenGL Examples/LearnJUCEOpenGL/Source/Shaders/Vert.vert"/>
+        <FILE id="Jt2BrY" name="Vert.vert" compile="0" resource="1" file="Source/Shaders/Vert.vert"/>
+        <FILE id="JBrKKa" name="Frag.frag" compile="0" resource="1" file="Source/Shaders/Frag.frag"/>
       </GROUP>
       <FILE id="X05egM" name="MainComponent.h" compile="0" resource="0" file="Source/MainComponent.h"/>
       <FILE id="yiX7Pz" name="MainComponent.cpp" compile="1" resource="0"
@@ -17,8 +17,8 @@
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" osxCompatibility="10.14 SDK"/>
-        <CONFIGURATION isDebug="0" name="Release" osxCompatibility="10.14 SDK"/>
+        <CONFIGURATION isDebug="1" name="Debug" osxCompatibility="10.14 SDK" macOSDeploymentTarget="10.14"/>
+        <CONFIGURATION isDebug="0" name="Release" osxCompatibility="10.14 SDK" macOSDeploymentTarget="10.14"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../../../../../Users/cc/Dev/JUCE/modules"/>

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -7,6 +7,7 @@
 */
 
 #include "MainComponent.h"
+#include "BinaryData.h"
 //==============================================================================
 MainComponent::MainComponent()
 {
@@ -111,20 +112,7 @@ void MainComponent::timerCallback()
 }
 MainComponent::ShaderProgramSource MainComponent::parse_shaders()
 {
-    auto shader_folder = File::getCurrentWorkingDirectory();
-    while (!shader_folder.isRoot()) {
-        if (shader_folder.getFileName() == JUCEApplication::getInstance()->getApplicationName()) {
-            shader_folder = shader_folder.getChildFile("Source/Shaders/");
-            break;
-        }
-        shader_folder = shader_folder.getParentDirectory();
-    }
-    if (! shader_folder.exists()) {
-        jassertfalse;
-    }
-    const auto vertex_file = shader_folder.getChildFile("Vert.vert");
-    const auto fragment_file = shader_folder.getChildFile("Frag.frag");
-    return { vertex_file.loadFileAsString(), fragment_file.loadFileAsString() };
+    return { BinaryData::Vert_vert, BinaryData::Frag_frag };
 }
 GLuint MainComponent::create_shader(const GLenum type, const GLchar* source, const GLint source_length)
 {

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -48,19 +48,19 @@ void MainComponent::newOpenGLContextCreated()
     
     // Load the (x, y) positions (which are just the corners of the screen), into a static area of GPU memory.
     GL::glGenBuffers(1, &vertex_buff_ID);
-    GL::glBindBuffer(GL_ARRAY_BUFFER, vertex_buff_ID);
-    GL::glBufferData(GL_ARRAY_BUFFER, sizeof(GLfloat) * positions_count, positions, GL_STATIC_DRAW);
+    GL::glBindBuffer(juce::gl::GL_ARRAY_BUFFER, vertex_buff_ID);
+    GL::glBufferData(juce::gl::GL_ARRAY_BUFFER, sizeof(GLfloat) * positions_count, positions, juce::gl::GL_STATIC_DRAW);
     
     // Specify the attribute layout of the currently bound vertex buffer object (there's only one attribute - position).
     // The currently instantiated vertex array object will use this specification for each draw call.
     GL::glEnableVertexAttribArray(pos_attrib_id);
-    GL::glVertexAttribPointer(pos_attrib_id, num_floats_per_pos_attrib, GL_FLOAT, GL_FALSE,
+    GL::glVertexAttribPointer(pos_attrib_id, num_floats_per_pos_attrib, juce::gl::GL_FLOAT, juce::gl::GL_FALSE,
                               sizeof(GLfloat) * num_floats_per_pos_attrib, (const void*)0);     // For more that one attrib, can use a struct with a C++ macro to determine this void* offset.
 
     // Specify which (x, y) positions are used to draw two triangles in the shape of a rectangle (the screen) using the positions in the currently bound vertex buffer object.
     GL::glGenBuffers(1, &index_buff_ID);
-    GL::glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buff_ID);
-    GL::glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLuint) * elements_count, elements, GL_STATIC_DRAW);
+    GL::glBindBuffer(juce::gl::GL_ELEMENT_ARRAY_BUFFER, index_buff_ID);
+    GL::glBufferData(juce::gl::GL_ELEMENT_ARRAY_BUFFER, sizeof(GLuint) * elements_count, elements, juce::gl::GL_STATIC_DRAW);
     
     // No need to unbind the array, buffer, or shader program thanks to JUCE.
 }
@@ -75,8 +75,8 @@ void MainComponent::renderOpenGL()
     GL::glBindVertexArray(vertex_arr_ID);
     
     // The element (or index) buffer is still required to be bound at each draw call to specify how to use the positions in the buffer to draw the correct shape.
-    GL::glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buff_ID);
-    glDrawElements(GL_TRIANGLES, elements_count, GL_UNSIGNED_INT, nullptr);
+    GL::glBindBuffer(juce::gl::GL_ELEMENT_ARRAY_BUFFER, index_buff_ID);
+    juce::gl::glDrawElements(juce::gl::GL_TRIANGLES, elements_count, juce::gl::GL_UNSIGNED_INT, nullptr);
     
     // Benchmark the software renderer against the OpenGL renderer
     time_frames();
@@ -134,7 +134,7 @@ GLuint MainComponent::create_shader(const GLenum type, const GLchar* source, con
     
     // Check shader compilation success
     GLint success;
-    GL::glGetShaderiv(shID, GL_COMPILE_STATUS, &success);
+    GL::glGetShaderiv(shID, juce::gl::GL_COMPILE_STATUS, &success);
     if (!success) {
         char infoLog[512];
         GL::glGetShaderInfoLog(shID, 512, nullptr, infoLog);
@@ -145,9 +145,9 @@ GLuint MainComponent::create_shader(const GLenum type, const GLchar* source, con
 }
 GLuint MainComponent::create_program(const ShaderProgramSource& source)
 {
-    const auto vxID = create_shader(GL_VERTEX_SHADER, source.VertexSource.getCharPointer(),
+    const auto vxID = create_shader(juce::gl::GL_VERTEX_SHADER, source.VertexSource.getCharPointer(),
                                     sizeof(GLchar) * source.VertexSource.length());
-    const auto fsID = create_shader(GL_FRAGMENT_SHADER, source.FragmentSource.getCharPointer(),
+    const auto fsID = create_shader(juce::gl::GL_FRAGMENT_SHADER, source.FragmentSource.getCharPointer(),
                                     sizeof(GLchar) * source.FragmentSource.length());
     const auto spID = GL::glCreateProgram();
     GL::glAttachShader(spID, vxID);
@@ -156,7 +156,7 @@ GLuint MainComponent::create_program(const ShaderProgramSource& source)
     
     // Check program linking success
     GLint success;
-    GL::glGetProgramiv(spID, GL_LINK_STATUS, &success);
+    GL::glGetProgramiv(spID, juce::gl::GL_LINK_STATUS, &success);
     if (!success) {
         char infoLog[512];
         GL::glGetProgramInfoLog(spID, 512, nullptr, infoLog);

--- a/Source/Shaders/Frag.frag
+++ b/Source/Shaders/Frag.frag
@@ -1,5 +1,3 @@
-//#version 330 core
-// On macOS, only shader version 150 works, 330 isn’t supported
 #version 150
 
 uniform float distance;

--- a/Source/Shaders/Vert.vert
+++ b/Source/Shaders/Vert.vert
@@ -1,6 +1,3 @@
-//#version 330 core
-// On macOS, only shader version 150 works, 330 (and thus "layout") isn’t supported
-// layout(location = 0) in vec4 position;
 #version 150
 
 in vec4 position;


### PR DESCRIPTION
Adds @mhamilt 's suggestion to update parse_shaders() to read from BinaryData.

Adds juce:: prefix for building in JUCE 8. 